### PR TITLE
Avoid duplicate counts from search

### DIFF
--- a/servers/flask/core/lists/listutils.py
+++ b/servers/flask/core/lists/listutils.py
@@ -10,7 +10,7 @@ class ListUtils:
     def parse_sort_by(s):
         """
         Parses a sort by string, converting it into an array of arrays.
-        
+
         :param s: sort by string
         """
         if not s:
@@ -85,6 +85,7 @@ class ListUtils:
                     # TODO: support better non-strings with their culture-dependent representations
                     if rx.search(item[x]):
                         result.append(item)
+                        break
             else:
                 for p in properties:
                     if rx.search(item[p]):

--- a/servers/flask/runtests.py
+++ b/servers/flask/runtests.py
@@ -3,8 +3,8 @@ import unittest
 #
 # import the test cases that need to be run
 #
-#from tests.server_test import ServerTestCase
-#from tests.helpers_test import HelpersTestCase
+from tests.server_test import ServerTestCase
+from tests.helpers_test import HelpersTestCase
 from tests.array_test import ArrayUtilsTestCase
 
 if __name__ == "__main__":

--- a/servers/flask/tests/server_test.py
+++ b/servers/flask/tests/server_test.py
@@ -1,5 +1,7 @@
 import server
 import unittest
+from flask import json
+
 
 
 class ServerTestCase(unittest.TestCase):
@@ -18,12 +20,11 @@ class ServerTestCase(unittest.TestCase):
         """
         #print("end..")
 
-    def test_hello_world(self):
-        print("Hello World!")
-        assert True == True
-        
     def test_homepage(self):
         rv = self.app.get('/')
-        #print(rv.data)
-        print("Hello World!")
-        assert "<title>" in rv.data
+        assert b'<title>' in rv.data
+
+    def test_api(self):
+        rv = self.app.get('/api/colors?page=1&search=%&size=30&timestamp=2017-07-06T17%3A54%3A17.653Z')
+        data = json.loads(rv.data)
+        assert data["total"] == 1247


### PR DESCRIPTION
Existing search with keyword will count one entry multiple times if the search keyword appears in multiple field for same entry.

For example, there are in total 1247 entries in `colors.json`

```sh
$ grep -c hsvValue servers/flask/data/colors.json
1247
```

But search with keyword '%' would return 8729 in total which is more than all entries in the json.

```sh
$ curl -s "http://localhost:44555/api/colors?page=1&search=%&size=30&timestamp=2017-07-06T01%3A12%3A55.662Z" | jq .total
8729
```

The fix here properly breaks the search loop if one entry matches.